### PR TITLE
BUG FIX: Backup Output Failure. Issue #9390

### DIFF
--- a/src/usr/local/www/diag_backup.php
+++ b/src/usr/local/www/diag_backup.php
@@ -225,6 +225,8 @@ if ($_POST) {
 					header("Pragma: private");
 					header("Cache-Control: private, must-revalidate");
 				}
+
+				$GLOBALS['csrf']['rewrite-js'] = false;
 				echo $data;
 
 				exit;


### PR DESCRIPTION
Set CSRF `rewrite-js` flag to false, prior to outputting backup file.

- [x] Redmine Issue: https://redmine.pfsense.org/issues/9390
- [x] Ready for review